### PR TITLE
임시 더미데이터 삭제 후 정규 음식데이터api 요청

### DIFF
--- a/client/src/pages/AddMeal.tsx
+++ b/client/src/pages/AddMeal.tsx
@@ -48,12 +48,6 @@ const AddMeal = () => {
     axios.post('api/testSuccess', { method: 'POST', body: new FormData() });
   };
 
-  // 페이지 입장시 최초 1회 음식 이름 리스트 로드
-  useEffect(() => {
-    dispatch(asyncUpFetch());
-    console.log(foodNameData);
-  }, []);
-
   const AutoCompleteBox = () => {
     const matchWordList = foodNameData.filter(food =>
       food.name.match(regexValue!),
@@ -81,28 +75,36 @@ const AddMeal = () => {
     return (
       <>
         <ul className="menu bg-base-100 rounded-box">
-          {matchWordList.map((item, i) => {
-            return (
-              <li key={i}>
-                <a className={addmealCss.nogap}>
-                  <input
-                    type="checkbox"
-                    className="checkbox mr-3"
-                    value={item.name}
-                    onChange={e => {
-                      onChecked(e.target.checked, e.target.value);
-                    }}
-                    checked={selectedFood.includes(item.name) ? true : false}
-                  />
-                  {getHighlightedText(item.name, searchInputValue)}
-                </a>
-              </li>
-            );
-          })}
+          {matchWordList
+            .map((item, i) => {
+              return (
+                <li key={i}>
+                  <a className={addmealCss.nogap}>
+                    <input
+                      type="checkbox"
+                      className="checkbox mr-3"
+                      value={item.name}
+                      onChange={e => {
+                        onChecked(e.target.checked, e.target.value);
+                      }}
+                      checked={selectedFood.includes(item.name) ? true : false}
+                    />
+                    {getHighlightedText(item.name, searchInputValue)}
+                  </a>
+                </li>
+              );
+            })
+            .splice(0, 10)}
         </ul>
       </>
     );
   };
+
+  // 페이지 입장시 최초 1회 음식 이름 리스트 로드
+  useEffect(() => {
+    dispatch(asyncUpFetch());
+    console.log(foodNameData);
+  }, []);
 
   return (
     <div className="flex flex-col w-full">

--- a/client/src/pages/AddMeal.tsx
+++ b/client/src/pages/AddMeal.tsx
@@ -2,27 +2,25 @@ import React, { useEffect, useState } from 'react';
 import { getRegExp } from 'korean-regexp';
 import addmealCss from './AddMeal.module.css';
 import { useDispatch, useSelector } from 'react-redux';
-import { RootState } from '../redux/store';
-import { setFoodNames } from '../redux/slice/foodNameSlice';
+import { AppDispatch, RootState } from '../redux/store';
+import { asyncUpFetch, setFoodNames } from '../redux/slice/foodNameSlice';
 import { setSelectedFood } from '../redux/slice/seletedFoodSlice';
 import { Link } from 'react-router-dom';
 import axios, { Axios } from 'axios';
 
 const AddMeal = () => {
-  const dispatch = useDispatch();
+  const dispatch = useDispatch<AppDispatch>();
 
   const selectedFood: string[] = useSelector(
     (store: RootState) => store.selectedFoods.checkedInput,
   );
 
+  const foodNameData: FoodNameType[] = useSelector((store: RootState) => {
+    return store.foodNames.value;
+  });
+
   const [searchInputValue, setsearchInputValue] = useState<string>(''); //검색창에 들어가는 값
   const [regexValue, setRegexValue] = useState<RegExp>(); //검색창에 들어가는 값을 정규식으로 변환해서 들어가는 값(라이브러리 이용할때 씀)
-  const [foodNameList, setFoodNameList] = useState<FoodNameType[]>([]);
-
-  const fetchData = async () => {
-    const foodData = (await axios.get('/api/foodName')).data.message;
-    setFoodNameList(foodData);
-  };
 
   const handleInputValue = (e: React.ChangeEvent<HTMLInputElement>) => {
     const getKorean: RegExp = getRegExp(e.target.value, {});
@@ -50,9 +48,15 @@ const AddMeal = () => {
     axios.post('api/testSuccess', { method: 'POST', body: new FormData() });
   };
 
+  // 페이지 입장시 최초 1회 음식 이름 리스트 로드
+  useEffect(() => {
+    dispatch(asyncUpFetch());
+    console.log(foodNameData);
+  }, []);
+
   const AutoCompleteBox = () => {
-    const matchWordList = foodNameList.filter(text =>
-      text.name.match(regexValue!),
+    const matchWordList = foodNameData.filter(food =>
+      food.name.match(regexValue!),
     );
 
     const getHighlightedText = (text: string, highlight: string) => {
@@ -99,11 +103,6 @@ const AddMeal = () => {
       </>
     );
   };
-
-  // 페이지 입장시 최초 1회 음식 이름 리스트 로드
-  useEffect(() => {
-    fetchData();
-  }, []);
 
   return (
     <div className="flex flex-col w-full">

--- a/client/src/redux/slice/foodNameSlice.ts
+++ b/client/src/redux/slice/foodNameSlice.ts
@@ -1,17 +1,42 @@
-import { createSlice } from '@reduxjs/toolkit';
+import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
+import axios from 'axios';
+
+const asyncUpFetch = createAsyncThunk(
+  'foodNameSlice/asyncUpFetch',
+  async () => {
+    const res = (await axios.post('/api/getFoodsAll')).data.message;
+    const foodNameData = await res.map((el: Food) => {
+      return el.name;
+    });
+    return foodNameData;
+  },
+);
 
 const foodNameSlice = createSlice({
   name: 'foodNames',
   initialState: {
-    foodNameList: [],
+    value: [],
+    status: 'Welcome',
   },
   reducers: {
     setFoodNames(state, { payload }) {
-      state.foodNameList = payload;
+      state.value = payload;
     },
+  },
+  extraReducers: builder => {
+    builder.addCase(asyncUpFetch.pending, (state, action) => {
+      state.status = 'loading';
+    });
+    builder.addCase(asyncUpFetch.fulfilled, (state, action) => {
+      state.value = action.payload;
+      state.status = 'complete';
+    });
+    builder.addCase(asyncUpFetch.rejected, (state, action) => {
+      state.status = 'fail';
+    });
   },
 });
 
 export const { setFoodNames } = foodNameSlice.actions;
-
+export { asyncUpFetch };
 export default foodNameSlice.reducer;


### PR DESCRIPTION
## 작업
- [ ] ✨ 새로운 기능, 레이아웃
- [ ] 🐛 버그 수정
- [x] 🚀 성능 개선
- [ ] 📑 문서 수정
<!--
ex) 중복 체크 가능 >_<!
- [ ] ✨ 새로운 기능, 레이아웃
- [x] 🐛 버그 수정
- [x] 🚀 성능 개선
- [ ] 📑 문서 수정
-->

## 작업 개요
1. 임시 더미데이터 api를 삭제하고 정규 음식데이터 api를 요청하고 로드받았습니다.
2. 음식데이터에서 필요한 Key만 골라내서 사용합니다. 
<!-- 
ex) 
1. 아이스크림 신메뉴 "바나나 우유맛"이 추가되었습니다 ✨
2. 그에 따른 메뉴판을 리뉴얼
 -->

## 주의 사항
1. 데이터 양이 있기 때문에 맨처음 검색할 때 속도가 느립니다.. 
2. 1번을 이유로 api요청 시점과 로딩화면에 대해서 생각해 보면 좋겠습니다
3. 캐시 또는 로컬스토리지를 이용해서 데이터를 저장하면 redux를 이용해서 저장하는것보다 빠를까요? 이것도 생각해보겠습니다..
<!-- 
ex) 1. npm install 필요! (ㅁㅁ 라이브러리)
-->
