### PR TITLE
식단 CRUD 및 음식 api

### DIFF
--- a/server/dataAlias.js
+++ b/server/dataAlias.js
@@ -1,4 +1,5 @@
 const alias = {
+  _id: "id",
   식품명: "name",
   "1회제공량": "servingSize",
   "에너지(㎉)": "kiloCalories",
@@ -13,7 +14,6 @@ const alias = {
 };
 
 const keyChange = function (source) {
-  delete source._id;
   for (const key in source) {
     if (key in alias) {
       source[alias[key]] = source[key];

--- a/server/index.js
+++ b/server/index.js
@@ -13,12 +13,14 @@ app.use(cors());
 app.use("/api", bodyParser.urlencoded({ extended: true }));
 app.use("/api", bodyParser.json());
 
-// test api
-// app.post("/api/getFoodNamesAll", async function (req, res) {
-//   const result = (await db.foodData.find().toArray()).map((i) => i.식품명);
-//   console.log(result);
-//   res.send(result);
-// });
+app.post("/api/getFoodNamesAll", async function (req, res) {
+  const result = (await db.foodData.find().toArray()).map((i) => keyChange(i));
+  const filter = result.map((i) => ({id, name, kiloCalories}));
+  res.send({
+    status: "success",
+    message: filter,
+  });
+});
 
 app.post("/api/getFoodsAll", async function (req, res) {
   const result = (await db.foodData.find().toArray()).map((i) => keyChange(i));

--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -15,7 +15,7 @@ router.post("/saveMeal", async (req, res) => {
   let successMessage = "";
 
   // 유효성 검사
-  if (token == undefined || type == undefined || meal == undefined) {
+  if (token == undefined || type == undefined || meal == undefined || date == undefined) {
     failReason = "Invalid input";
   } else {
     const YMD = new Date(date).toISOString().substring(0, 10); // UTC
@@ -51,7 +51,7 @@ router.post("/getMeal", async (req, res) => {
   let successMessage = "";
 
   // 유효성 검사
-  if (token == undefined || type == undefined || meal == undefined) {
+  if (token == undefined || type == undefined || date == undefined) {
     failReason = "Invalid input";
   } else {
     const YMD = new Date(date).toISOString().substring(0, 10); // UTC
@@ -74,6 +74,35 @@ router.post("/getMeal", async (req, res) => {
   });
 });
 
+// 해당 날짜의 모든 식단 불러오기
+router.post("/getMealAll", async (req, res) => {
+  const { token, date } = req.body;
+  let failReason = "";
+  let successMessage = "";
+
+  // 유효성 검사
+  if (token == undefined || date == undefined) {
+    failReason = "Invalid input";
+  } else {
+    const YMD = new Date(date).toISOString().substring(0, 10); // UTC
+    mealData = await db.userMeal.find({
+      token: token,
+      date: new Date(YMD)
+    }).toArray();
+    
+    if (mealData.length > 0) {
+      successMessage = mealData;
+    } else {
+      failReason = "Not exists"
+    }
+  }
+
+  res.send({
+    status: failReason == "" ? "success" : "fail",
+    message: failReason == "" ? successMessage : failReason,
+  });
+});
+
 // 식단 수정하기
 router.post("/updateMeal", async (req, res) => {
   const { token, type, meal, date } = req.body;
@@ -81,7 +110,7 @@ router.post("/updateMeal", async (req, res) => {
   let successMessage = "";
 
   // 유효성 검사
-  if (token == undefined || type == undefined || meal == undefined) {
+  if (token == undefined || type == undefined || meal == undefined || date == undefined) {
     failReason = "Invalid input";
   } else {
     const YMD = new Date(date).toISOString().substring(0, 10); // UTC
@@ -110,7 +139,7 @@ router.post("/removeMeal", async (req, res) => {
   let successMessage = "";
 
   // 유효성 검사
-  if (token == undefined || type == undefined || meal == undefined) {
+  if (token == undefined || type == undefined || meal == undefined || date == undefined) {
     failReason = "Invalid input";
   } else {
     const YMD = new Date(date).toISOString().substring(0, 10); // UTC

--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -4,25 +4,120 @@ const db = require("../middleware/database");
 const { createToken, verifyToken } = require("../middleware/auth");
 const { encrypt } = require("../middleware/crypt");
 
-const pwRegex =
-  /^(?=.*[A-Za-z])(?=.*\d)(?=.*[$@$!%*#?&])[A-Za-z\d$@$!%*#?&]{8,}$/;
+const pwRegex = /^(?=.*[A-Za-z])(?=.*\d)(?=.*[$@$!%*#?&])[A-Za-z\d$@$!%*#?&]{8,}$/;
 const mailRegex = /^[A-Za-z0-9_\.\-]+@[A-Za-z0-9\-]+\.[A-Za-z0-9\-]+/;
 const nickReg = /^(?=.*[a-z0-9가-힣])[a-z0-9가-힣]{2,16}$/;
 
-// 오늘 식단 저장
-router.post("/saveTodayMeal", async (req, res) => {
-  const { userId, type, meal } = req.body;
+// 식단 저장
+router.post("/saveMeal", async (req, res) => {
+  const { token, type, meal, date } = req.body;
   let failReason = "";
   let successMessage = "";
 
-  if (userId == undefined || type == undefined || meal == undefined) {
+  // 유효성 검사
+  if (token == undefined || type == undefined || meal == undefined) {
     failReason = "Invalid input";
   } else {
-    const dateString = new Date().toISOString().substring(0, 10); // UTC
-    await db.userMeal.insertOne({
-      date: dateString,
+    const YMD = new Date(date).toISOString().substring(0, 10); // UTC
+    const isExists = await db.userData.countDocuments({
+      token: token,
+      date: new Date(YMD),
       type: type,
-      meal: meal,
+    });
+    // 중복 검사
+    if (isExists > 0) {
+      failReason = "Already saved";
+    } else {
+      await db.userMeal.insertOne({
+        token: token,
+        date: new Date(YMD),
+        type: type,
+        meal: meal
+      });
+      successMessage = "success";
+    }
+  }
+
+  res.send({
+    status: failReason == "" ? "success" : "fail",
+    message: failReason == "" ? successMessage : failReason,
+  });
+});
+
+// 식단 불러오기
+router.post("/getMeal", async (req, res) => {
+  const { token, type, date } = req.body;
+  let failReason = "";
+  let successMessage = "";
+
+  // 유효성 검사
+  if (token == undefined || type == undefined || meal == undefined) {
+    failReason = "Invalid input";
+  } else {
+    const YMD = new Date(date).toISOString().substring(0, 10); // UTC
+    mealData = await db.userMeal.findOne({
+      token: token,
+      date: new Date(YMD),
+      type: type
+    });
+
+    if (mealData !== undefined) {
+      successMessage = mealData;
+    } else {
+      failReason = "Not exists"
+    }
+  }
+
+  res.send({
+    status: failReason == "" ? "success" : "fail",
+    message: failReason == "" ? successMessage : failReason,
+  });
+});
+
+// 식단 수정하기
+router.post("/updateMeal", async (req, res) => {
+  const { token, type, meal, date } = req.body;
+  let failReason = "";
+  let successMessage = "";
+
+  // 유효성 검사
+  if (token == undefined || type == undefined || meal == undefined) {
+    failReason = "Invalid input";
+  } else {
+    const YMD = new Date(date).toISOString().substring(0, 10); // UTC
+    await db.userMeal.updateOne({
+      token: token,
+      date: new Date(YMD),
+      type: type
+    }, {
+      $set: {
+        meal
+      }
+    });
+    successMessage = "success";
+  }
+
+  res.send({
+    status: failReason == "" ? "success" : "fail",
+    message: failReason == "" ? successMessage : failReason,
+  });
+});
+
+// 식단 삭제
+router.post("/removeMeal", async (req, res) => {
+  const { token, type, meal, date } = req.body;
+  let failReason = "";
+  let successMessage = "";
+
+  // 유효성 검사
+  if (token == undefined || type == undefined || meal == undefined) {
+    failReason = "Invalid input";
+  } else {
+    const YMD = new Date(date).toISOString().substring(0, 10); // UTC
+    await db.userMeal.removeOne({
+      token: token,
+      date: new Date(YMD),
+      type: type
     });
     successMessage = "success";
   }


### PR DESCRIPTION
## 작업
- [x] ✨ 새로운 기능, 레이아웃
- [ ] 🐛 버그 수정
- [ ] 🚀 성능 개선
- [ ] 📑 문서 수정

## 작업 개요
1. 식단 CRUD api 기초 틀 작업
2. 모든 음식의 이름,칼로리,id 반환하는 api 추가
3. 음식 데이터에 id 포함하도록 변경

## 주의 사항
1. 식단 저장 시, 이미 같은 날짜에 등록하려는 식사 구분(아침 점심 등)이 등록되어 있을 경우 저장에 실패함. 덮어쓰도록 하는게 나은지 논의 필요합니다.
2. 식단 CRUD api는 공통적으로 엑세스 토큰, 식사 구분, timestamp 형식의 날짜 값을 전달해야 합니다.
